### PR TITLE
✨ Add syntax for aliasing keys of nested object.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,16 +9,16 @@
 
 ## Installation
 
-Require this package with composer.
+Require this package with composer:
 ```bash
 composer require mathieutu/exporter
 ```
 
 ## Use cases
 
-Because pictures are worth thousands words..:
+Because pictures are worth thousands words:
 
-The Exporter let you write this:
+The Exporter package let you write this:
 
 <p align="center">
     <a href="https://raw.githubusercontent.com/mathieutu/exporter/master/assets/after.png">
@@ -44,15 +44,16 @@ For example, I use it a lot with Laravel Eloquent Resources, or as an easier alt
 
 ## Usage
 
-Just use the `\MathieuTu\Exporter\Exporter` trait on your classes. 
-You also can use directly the `\MathieuTu\Exporter\ExporterService::exportFrom($exportable, $attributes)` static method on array, or if you don't want to add the trait.
+Use the `\MathieuTu\Exporter\Exporter` trait on your classes. 
+You also can use directly the `\MathieuTu\Exporter\ExporterService::exportFrom($exportable, $attributes)` static method on array or objects, or if you don't want or can't add the trait.
 
 You can export from arrays, objects with `ArrayAccess` interface, or any standard objects.
 
-The response will be a [Laravel Collection](https://laravel.com/docs/master/collections) (but you absolutely don't need Laravel, **this package is totally framework agnostic**). If you don't know how to use collections, you can use it exactly like an array, or use `toArray()` method to get a real one.
+The response will be a [Laravel Collection](https://laravel.com/docs/master/collections) (but you absolutely don't need Laravel, **this package is totally framework agnostic**). 
+If you don't know how to use collections, you can **use it exactly like an array**, or use `toArray()` method to get a real one.
 
 ### Examples
-_(You can find all this examples in package tests)_
+_(You can find all this examples in [package tests](./tests/ExporterServiceTest.php))_
 
 For the examples, and to cover all the possible ways to use this package, we'll consider this object as input:
 
@@ -149,6 +150,20 @@ $object->export(['baz' => ['*' => ['baz1', 'baz3']]]);
 
 
 
+#### Set an alias as key:
+
+```php
+$object->export(['foo', 'bar.bar2 as secondBar']); 
+/* 
+[
+    'foo' => testFoo,
+    'secondBar' => 'testBar2',
+]
+*/
+```
+
+
+
 #### Export result of a function
 
 ```php
@@ -164,6 +179,6 @@ This Exporter package is an open-sourced software licensed under the [MIT licens
 
 ### Contributing
 
-Issues and PRs are obviously welcomed and encouraged, as well for new features than documentation.
+Issues and PRs are obviously welcomed and encouraged, both for bugs and new features as well as documentation.
 Each piece of code added should be fully tested, but we can do that all together, so please don't be afraid by that. 
 

--- a/src/ExporterService.php
+++ b/src/ExporterService.php
@@ -129,13 +129,17 @@ class ExporterService
             return $export;
         }
 
+        if (preg_match('/^(.*) as (.*)$/', $attribute, $matches)) {
+            return [$matches[2] => $this->getAttributeValue($matches[1])];
+        }
+
         return [$attribute => $this->getAttributeValue($attribute)];
     }
 
     protected function attributeIsAFunction($attribute)
     {
-        if (preg_match("/(.*)\((.*)\)$/", $attribute, $groups)) {
-            return [$groups[1] => call_user_func_array([$this->exportable, $groups[1]], array_map('trim', explode(',', $groups[2])))];
+        if (preg_match("/(.*)\((.*)\)$/", $attribute, $matches)) {
+            return [$matches[1] => call_user_func_array([$this->exportable, $matches[1]], array_map('trim', explode(',', $matches[2])))];
         }
 
         return null;

--- a/tests/ExporterServiceTest.php
+++ b/tests/ExporterServiceTest.php
@@ -58,8 +58,7 @@ class ExporterServiceTest extends TestCase
             collect(['foo' => 'testFoo', 'bar' => null]),
             $this->export(
                 ['foo', 'bar'],
-                new class
-                {
+                new class {
                     public $foo = 'testFoo';
                     private $bar = 'testBar';
                 }
@@ -73,8 +72,7 @@ class ExporterServiceTest extends TestCase
             collect(['foo' => 'testFoo', 'bar' => 'testBar']),
             $this->export(
                 ['foo()', 'bar(testBar)'],
-                new class
-                {
+                new class {
                     public function foo(): string
                     {
                         return 'testFoo';
@@ -146,17 +144,30 @@ class ExporterServiceTest extends TestCase
     {
         $this->assertEquals(
             collect([
-                'foo.*'            => null,
-                'bar.*'            => ['testBar1', 'testBar2'],
+                'foo.*' => null,
+                'bar.*' => ['testBar1', 'testBar2'],
                 'nested.*.nested1' => ['testNested1A', 'testNested1B'],
             ]),
             $this->export(['foo.*', 'bar.*', 'nested.*.nested1'], [
-                'foo'    => 'testFoo',
-                'bar'    => collect(['bar1' => 'testBar1', 'bar2' => 'testBar2']),
+                'foo' => 'testFoo',
+                'bar' => collect(['bar1' => 'testBar1', 'bar2' => 'testBar2']),
                 'nested' => [
                     ['nested1' => 'testNested1A', 'nested2' => 'testNested2A'],
                     ['nested1' => 'testNested1B', 'nested2' => 'testNested2B'],
                 ],
+            ])
+        );
+    }
+
+
+    public function testExportAliases()
+    {
+        $this->assertEquals(
+            collect(['foo' => 'testFoo', 'barKey' => 'testBar2', 'bazKey' => 'testBaz']),
+            $this->export(['foo', 'bar.bar2 as barKey', 'baz as bazKey'], [
+                'foo' => 'testFoo',
+                'bar' => ['bar1' => 'testBar1', 'bar2' => 'testBar2'],
+                'baz' => 'testBaz',
             ])
         );
     }


### PR DESCRIPTION
This PR give you the ability to write things like this:

```php
$object->export(['foo as fooKey']); // ['fooKey' => testFoo]
```